### PR TITLE
Added support for @use rules.

### DIFF
--- a/src/compile.js
+++ b/src/compile.js
@@ -12,9 +12,9 @@ function unwrapValue(value) {
 }
 
 var Compile = {
-  fromString: function(value) {
+  fromString: function(value, useRules) {
     var wrappedValue = wrapValue(value);
-    var s = sass.renderSync({ data: wrappedValue });
+    var s = sass.renderSync({ data: useRules.join(';\n') + ';\n' + wrappedValue });
     var compiled = String(s.css);
     var minifiedCompiled = cssmin(compiled);
     return unwrapValue(minifiedCompiled);

--- a/src/declaration.js
+++ b/src/declaration.js
@@ -23,7 +23,7 @@ Declaration.prototype = {
     var replacedValue = declarationStore.replaceVariables(assignedValue);
 
     this.variable = new Variable(assignedVariable);
-    this.value = new Value(replacedValue);
+    this.value = new Value(replacedValue, declarationStore.useRules);
     this.global = hasGlobalFlag(replacedValue);
 
     declarationStore.addDeclaration(this);

--- a/src/declarationStore.js
+++ b/src/declarationStore.js
@@ -2,11 +2,16 @@
 
 function DeclarationStore() {
   this.declarations = [];
+  this.useRules = [];
 }
 
 DeclarationStore.prototype = {
   addDeclaration: function(declaration) {
     this.declarations.push(declaration);
+  },
+
+  addUseRule: function(useRule) {
+    this.useRules.push(useRule);
   },
 
   replaceVariables: function(scssString) {

--- a/src/processor.js
+++ b/src/processor.js
@@ -31,7 +31,8 @@ function makeObject(declarations, options) {
 
 function filterLines(line) {
   return EMPTY_LINES.every(function(lineValue) {
-    return line !== lineValue && line.slice(0, 2) !== COMMENT_DELIMETER && line.indexOf('@import') < 0;
+    return line !== lineValue && line.slice(0, 2) !== COMMENT_DELIMETER
+        && line.indexOf('@import') < 0 && line.indexOf('@use') < 0;
   });
 }
 
@@ -93,8 +94,14 @@ function declarationsFromString(path, declarationStore, options) {
     data = extractScope(data, options.scope);
   }
 
-  var lines = String(data).split(LINE_DELIMITER).map(normalizeLines).filter(filterLines);
-  return lines.map(function(line) {
+  var lines = String(data).split(LINE_DELIMITER).map(normalizeLines);
+  var useRules = lines.filter(function(line) { return line.match(/^@use .+/); });
+
+  useRules.forEach(function(useRule) {
+    declarationStore.addUseRule(useRule);
+  });
+
+  return lines.filter(filterLines).map(function(line) {
     return new Declaration(line, declarationStore);
   });
 }

--- a/src/value.js
+++ b/src/value.js
@@ -7,14 +7,14 @@ function transforms(value) {
   return utilities.removeInlineComments(utilities.removeFlags(value));
 }
 
-function Value(scssString) {
-  this._parse(scssString);
+function Value(scssString, useRules) {
+  this._parse(scssString, useRules);
 }
 
 Value.prototype = {
-  _parse: function(scssString) {
+  _parse: function(scssString, useRules) {
     var transformed = transforms(scssString);
-    var compiled = compile.fromString(transformed);
+    var compiled = compile.fromString(transformed, useRules);
     this.value = compiled.trim();
   }
 };


### PR DESCRIPTION
This PR adds support for @use rules. For example, this makes it possible to use `color.adjust` in your exported variables (which requires the use of `@use "sass:color"`).