### PR TITLE
Remove legacy JS api

### DIFF
--- a/src/compile.js
+++ b/src/compile.js
@@ -14,7 +14,7 @@ function unwrapValue(value) {
 var Compile = {
   fromString: function(value) {
     var wrappedValue = wrapValue(value);
-    var s = sass.renderSync({ data: wrappedValue });
+    var s = sass.compileString(wrappedValue);
     var compiled = String(s.css);
     var minifiedCompiled = cssmin(compiled);
     return unwrapValue(minifiedCompiled);


### PR DESCRIPTION
See https://sass-lang.com/documentation/breaking-changes/legacy-js-api/

Since 1.45, `render` and `renderSync` are replaced with the "modern" JS api.

This PR does changed from `renderSync` to `compileString`